### PR TITLE
Sweets/seo

### DIFF
--- a/components/HomePage/HomePage.tsx
+++ b/components/HomePage/HomePage.tsx
@@ -30,7 +30,7 @@ const HomePage: NextPage<HomePageProps> = ({ collection }) => {
 
   return (
     <>
-      <SeoHead />
+      <SeoHead image={ipfsImage(collection.editionMetadata.imageURI)} />
       <div
         className="font-body flex grid grid-cols-6 p-5 justify-center align-center "
         style={{ backgroundColor: 'black' }}

--- a/components/SeoHead/SeoHead.js
+++ b/components/SeoHead/SeoHead.js
@@ -1,11 +1,11 @@
 import Head from 'next/head'
 
-const SeoHead = () => {
+const SeoHead = ({
+  image = 'https://nftstorage.link/ipfs/bafybeid2v7ewhc3nsogbqrginxwys2ky3lxbmde72iafqmafsojz22f64e',
+}) => {
   const title = process.env.NEXT_PUBLIC_TITLE
   const description = process.env.NEXT_PUBLIC_DESCRIPTION_TEXT
-  const image =
-    'https://nftstorage.link/ipfs/bafybeid2v7ewhc3nsogbqrginxwys2ky3lxbmde72iafqmafsojz22f64e'
-  const url = 'https://notyetno.xyz/'
+  const url = 'https://march8.xyz/'
 
   return (
     <Head>

--- a/metadata/march8-metadata.json
+++ b/metadata/march8-metadata.json
@@ -1,6 +1,6 @@
 {
-  "description": "march 8 EP - a collaboration between musicians Sol Siete, Little Miss Music, Calispeedway & Yaxx Castillo, Executive Produced by sweetman.eth",
+  "description": "M8 EP - a collaboration between musicians Sol Siete, Little Miss Music, Calispeedway & Yaxx Castillo, Executive Produced by sweetman.eth",
   "image": "ipfs://bafybeiazt3ggkq4rzmcv2l2xp23ksjoatg3edfmqn4bblsspmn7xiee26m",
-  "name": "march 8",
-  "animation_url": "https://cdn.warpsound.ai/ipfs/QmVYW5vHaV322Kvp2So5ErngP1PrDUneYqo4e9TNygAGSn?playlist-url=https://nftstorage.link/ipfs/bafkreibdzjxrdrii3e5e27vg3k42vaubsbdopivvudt6ouxj5lchyxqapa"
-  }
+  "name": "M8",
+  "animation_url": "https://cdn.warpsound.ai/ipfs/QmVYW5vHaV322Kvp2So5ErngP1PrDUneYqo4e9TNygAGSn?playlist-url=https://nftstorage.link/ipfs/bafkreihaj2g6si7afjque4yueuvdcg4py2qbl6daspiyekmhnnevce3gza"
+}

--- a/metadata/march8-playlist.json
+++ b/metadata/march8-playlist.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": "1",
-  "coverArtUrl": "https://nftstorage.link/ipfs/bafkreidw73ithvucesz7aebfucrjaglnjtkzygemevakkrnmylq2chwsa4",
-  "title": "march 8",
-  "artist": "female compilation",
+  "coverArtUrl": "https://nftstorage.link/ipfs/bafybeigoqxhuo76oop7uvqnw667olpaq5y3kxree26xatskveeqeehwg4u/cover.png",
+  "title": "female compilation EP",
+  "artist": "M8",
   "chain": "Polygon",
   "contractAddress": "",
   "tokenId": "",
@@ -10,17 +10,28 @@
   "hideBranding": true,
   "items": [
     {
-      "url": "https://nftstorage.link/ipfs/Qmc3u1nFDd8Dv2FoACZMDKgqKgexwk6Cnu2zhR6yuHs9p2/SOL%20SIETE%20%20HOY%20LLUEVE%20x%20Dir.%20Camille%20Constant.mp3",
+      "url": "https://nftstorage.link/ipfs/bafybeigoqxhuo76oop7uvqnw667olpaq5y3kxree26xatskveeqeehwg4u/Yagna_Castillo_DejaVu.mp3",
       "kind": "audio",
-      "artist": "sol siete",
-      "title": "hoy llueve"
+      "artist": "Yagna Castillo",
+      "title": "DejaVu"
     },
     {
-      "url": "https://nftstorage.link/ipfs/Qmc3u1nFDd8Dv2FoACZMDKgqKgexwk6Cnu2zhR6yuHs9p2/3.13.2023_LittleMissMusic_Genesis.mp3",
+      "url": "https://nftstorage.link/ipfs/bafybeidvq7f77ai4cbhlrdy5smadlr4m3jima2h4d4y3vsepgbyd5w67py/Nena1992_Look_at_me.mp3",
       "kind": "audio",
-      "artist": "little miss music",
+      "artist": "Nena1992",
+      "title": "Look at me"
+    },
+    {
+      "url": "https://nftstorage.link/ipfs/bafybeigoqxhuo76oop7uvqnw667olpaq5y3kxree26xatskveeqeehwg4u/LittleMissMusic_Genesis.mp3",
+      "kind": "audio",
+      "artist": "Little Miss Music",
       "title": "genesis"
+    },
+    {
+      "url": "https://nftstorage.link/ipfs/bafybeigoqxhuo76oop7uvqnw667olpaq5y3kxree26xatskveeqeehwg4u/sol_siete_hoy_llueve.wav",
+      "kind": "audio",
+      "artist": "Sol Siete",
+      "title": "Hoy llueve"
     }
-    
   ]
 }


### PR DESCRIPTION
- new image from `collection` info with fallback to Not yet, no? cover.